### PR TITLE
Fix reference to COARDS.

### DIFF
--- a/appa.adoc
+++ b/appa.adoc
@@ -191,7 +191,7 @@ Attribute
 | **`positive`**
 | S
 | C
-| [<<COARDS>>]
+| <<COARDS>>
 | Direction of increasing vertical coordinate value.
 
 | **`references`**


### PR DESCRIPTION
As can be seen with all the other bibliography references, the square brackets come for free now.