### PR TITLE
correct the CF link

### DIFF
--- a/pr01.adoc
+++ b/pr01.adoc
@@ -7,7 +7,7 @@ Contains links to: previous draft and current working draft documents;
 applications for processing CF conforming files; email list for
 discussion about interpretation, clarification, and proposals for
 changes or extensions to the current conventions.
-link:$$http://www-pcmdi.llnl.gov/cf/$$[http://www-pcmdi.llnl.gov/cf/]
+link:$$http://cfconventions.org/$$[http://cfconventions.org/]
 
 Revision history: ::
 This document will be updated to reflect agreed changes to the standard


### PR DESCRIPTION
Dear Richard

I respect your respecting the existing text! I think that's the right thing to do regarding the conventions, but since this new version may well supersede the existing 1.6 document, or be maintained together with it, I think it makes sense to correct the link.

Best wishes

Jonathan