### PR TITLE
Turn on numbering for Appendix H.

### DIFF
--- a/cf-conventions.adoc
+++ b/cf-conventions.adoc
@@ -88,7 +88,7 @@ include::appf.adoc[]
 :numbered!:
 include::appg.adoc[]
 
-:numbered!:
+:numbered:
 include::apph.adoc[]
 
 :numbered!:


### PR DESCRIPTION
Unlike the other appendices, appendix H does use numbers for the section & sub-sections.